### PR TITLE
BugFix: Laden der Weiteren Zutaten

### DIFF
--- a/source/src/definitionen.h
+++ b/source/src/definitionen.h
@@ -5,8 +5,8 @@
 //#define DEBUG true
 
 //Version
-#define VERSION "1.4.3.0"
-#define VERSION_INT 1040300
+#define VERSION "1.4.3.1"
+#define VERSION_INT 1040301
 //Datenbankversion
 //V17 highGravityFaktor Prozentwert
 //    in Tabelle Ausruestunpog Verdampfungsziffer hinzugefügt (Korrektur Nachgussmenge wird nun nicht mehr gebraucht)

--- a/source/src/mainwindowimpl.cpp
+++ b/source/src/mainwindowimpl.cpp
@@ -3275,6 +3275,8 @@ void MainWindowImpl::LeseSuddatenDB(bool aktivateTab)
           berEwz -> setAttribute(Qt::WA_DeleteOnClose);
 
           ewz -> ergWidget = berEwz;
+          ewz -> setBierWurdeGebraut(BierWurdeGebraut);
+          ewz -> setBierWurdeAbgefuellt(BierWurdeAbgefuellt);
           //Funktionen verknüpfen das das objekt die Daten holen kann
           connect(ewz, SIGNAL( sig_vorClose(int) ), this, SLOT( slot_ewzClose(int) ));
           connect(ewz, SIGNAL( sig_getEwzTyp(QString) ), this, SLOT( slot_getEwzTyp(QString) ));
@@ -3301,8 +3303,6 @@ void MainWindowImpl::LeseSuddatenDB(bool aktivateTab)
             ewz -> setEwListe(ewzListe);
             ewz -> setHopfenListe(HopfenListe);
           }
-          ewz -> setBierWurdeGebraut(BierWurdeGebraut);
-          ewz -> setBierWurdeAbgefuellt(BierWurdeAbgefuellt);
           connect(ewz, SIGNAL( sig_Aenderung() ), this, SLOT( slot_EwzAenderung() ));
 
           //Ergebnisswidget dem Layout zuordnen


### PR DESCRIPTION
Beim Laden der Weiteren Zutaten wird der Dialog zum Ersetzten angezeigt obwohl der Rohstoff vorhanden ist