### PR TITLE
travis-ci automatic deployment for macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,59 @@
+language: cpp
+
+os:
+  - linux
+  - osx
+
+dist: trusty
+
+compiler:
+  - clang
+  - gcc
+
+sudo: required
+
+matrix:
+  # Qt no longer supports GCC on OSX.
+  allow_failures:
+    - os: osx
+      compiler: gcc
+
+before_install:
+  - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew update ; fi
+  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then sudo add-apt-repository --yes ppa:ubuntu-sdk-team/ppa ; fi
+  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then sudo apt-get update -qq ; fi
+
+install:
+  - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then brew install qt ; fi
+  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then sudo apt-get install qtbase5-dev qtdeclarative5-dev libqt5webkit5-dev libsqlite3-dev libqt5svg5* ; fi
+  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then sudo apt-get install qt5-default qttools5-dev-tools ; fi
+
+before_script:
+  - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then chmod +x ./build_macos.sh ; fi
+  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then chmod +x ./deployment/debian/deploy.sh ; fi
+  # comment out #define DEBUG true
+  #- sed -i '' -e '/^#define DEBUG true/ s/^#*/\/\/#/' ./source/src/definitionen.h 
+script:
+  - if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then TAG_NAME=${TRAVIS_TAG} ./build_macos.sh /usr/local/opt/qt/bin/ ; fi
+  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then cd source; fi
+  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then qmake -project ; fi
+  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then qmake brauhelfer.pro ; fi
+  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then make ; fi
+#  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then ./deployment/debian/deploy.sh ./bin/kleiner-brauhelfer /opt/Qt/5.10.0/gcc_64/bin/ ; fi
+
+#  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 100 ; fi
+#  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then sudo update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-6 100 ; fi
+#  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then chmod +x build_linux.sh ; fi
+#  - if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then TAG_NAME=${TRAVIS_TAG} CXX="g++-6" CC="gcc-6" ./build_linux.sh ; fi
+
+deploy:
+  provider: releases
+  api_key:
+    secure: P+c36BH2jYRUUP+ycXh/lS3MLFWb92Q5RInWLq4/Cn/4O/9MXi+sZHYEsKspp/lVzno112aGksA/MVrU5bPsLB6Af1YGG1WFTR9rtS8bxTm50l4fdm5m3gkt4VDfmzx2bTD5PJMRLsH3tcg+GF5ugysY5HtQuoWfO/HKSJA0jAYN+7qa80bMK0xfj5z/O/sG64avJ2Wpk/rLPi9pwGW6Oun8FLyG0Phg5e8zbjxWCogsOBYgJh+QY5EeYdB988RZK7GPGDKGTjn4TIHUinoJNfUdd/LgSgIbGzEiPrbzLuzOVDx9en+DS6O3GZ/4mEoKKCK8Iow6x0uJpnlX/phY4y1B5HR4oFKq6R/jmfWbkCllxza/HDnkjVVpQfgfn7rszNl4cmgflZzdalGrbnhXugtDWe+fmjjUkZQUyR4sdGVi953wMl+PfzOYDECkeLQm6kjfY4Pm6UCMXk3luOOjOVXU6/gEsYbTAFZkc/Cm46XdKwyhCZR9vENViF09r3V5HxWe8rAuX386p0RqARU/OcD+0h4xxcmhqKUYlYZJgTDhf8epOkrHH+1e40JvaOFUS1E862kAokpDmxNLFt7KQq0tRP/dyrBRT9d6Wg0fylqDXvKwpznRWV87QrAuEpvbTcSgkYDRYpY8SL5KcyhglMd/lcnKhMiyUxAq/ipD3JI=
+  file:  "./bin/kb_macos_*.zip"
+#  file:  "./kb_linux_*.tar.gz"
+  file_glob: "true"
+  skip_cleanup: true
+  overwrite: true
+  on:
+    all_branches: true

--- a/build_macos.sh
+++ b/build_macos.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+QTDIR=$1
+if [ "${QTDIR}" = "" ]; then
+  echo  "Usage: build.sh <qt-bin-directory>"
+  exit 1
+fi
+
+PRO="source/brauhelfer.pro"
+
+# comment out #define DEBUG true
+sed -i '' -e '/^#define DEBUG true/ s/^#*/\/\/#/' ./source/src/definitionen.h
+
+${QTDIR}/qmake "${PRO}" || exit 1
+make clean && make || exit 1
+${QTDIR}/lupdate "${PRO}" || exit 1
+${QTDIR}/lrelease "${PRO}" || exit 1
+./deployment/macOS/deploy.sh ./bin/kleiner-brauhelfer.app "${QTDIR}" || exit 1

--- a/deployment/macOS/deploy.sh
+++ b/deployment/macOS/deploy.sh
@@ -59,6 +59,9 @@ echo "* Patching '${PLIST}'..."
 # Add finder icon
 /usr/libexec/PlistBuddy -c "Set :CFBundleIconFile 'AppIcon'" ${PLIST}
 
+# Minimum OS is High Sierra to be sure
+/usr/libexec/PlistBuddy -c "Add :LSMinimumSystemVersion string '10.13'" ${PLIST}
+
 # Add information for Finder
 /usr/libexec/PlistBuddy -c "Delete :CFBundleDisplayName" ${PLIST}
 /usr/libexec/PlistBuddy -c "Add :CFBundleDisplayName string 'kleiner-brauhelfer'" ${PLIST} || exit 1


### PR DESCRIPTION
Automatic build and release deployment of macOS version of "kleiner-brauhelfer" with the help of travis-ci.

The api_key has to be changed to this repositories personal key. Use the Travis CI command line client and `travis setup releases`.

Look at https://travis-ci.org/realholgi/kleiner-brauhelfer for the buld logs and the resulting github releases page https://github.com/realholgi/kleiner-brauhelfer/releases . The linux versions are also built, but I have no clue how to package them correctly.