### PR TITLE
Fixed quote escaping in SQL queries for Hefe names in recipes.

### DIFF
--- a/source/src/mainwindowimpl.cpp
+++ b/source/src/mainwindowimpl.cpp
@@ -5257,7 +5257,7 @@ void MainWindowImpl::CheckRohstoffeVorhanden() {
     if (checkBox_MerklisteMengen->isChecked()) {
       QSqlQuery query;
       QString sql;
-      sql = "SELECT * FROM 'Sud' WHERE MerklistenID=1 AND AuswahlHefe='" + s +
+      sql = "SELECT * FROM 'Sud' WHERE MerklistenID=1 AND AuswahlHefe='" + s.replace("'", "''") +
             "'";
       if (!query.exec(sql)) {
         // Fehlermeldung Datenbankabfrage


### PR DESCRIPTION
Beim Auswählen einer Hefe mit dem Namen "Mangrove Jack's US West Coast M44" (enthält ein Quote-Zeichen (')) innerhalb eines Rezeptes bin ich auf eine SQL Fehlermeldung gestoßen. Dies ist vermutlich der angemessene Fix dafür.